### PR TITLE
Keep stable order of tasks on the taskbar.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1572,6 +1572,14 @@ TaskBar.prototype =
             this.removeTaskInList(window);
             this.hidePreview();
         }
+        this.tasksList.sort(
+            function(taskA, taskB)
+	    {
+                let [windowTaskA, buttonTaskA, signalsTaskA] = taskA;
+                let [windowTaskB, buttonTaskB, signalsTaskB] = taskB;
+                return windowTaskA.get_stable_sequence() > windowTaskB.get_stable_sequence();
+            }
+        );
     },
 
     //Active Tasks


### PR DESCRIPTION
The tasks are sorted in order of their start up time on the task bar even though new apps are started and other apps are terminated. This is a must for easy navigation and UI best practise – icons are not continuously moving without user's intention.

The order of the tasks is defined base on stable sequence IDs of their windows (see https://developer.gnome.org/meta/stable/MetaWindow.html#meta-window-get-stable-sequence).

----

My wish list (but I do not know the GNOME extension development and API enough):
* User defined order of the tasks on the task bar (very needed function of good old GNOME 2).
  * Any app icon on the task bar can be dragged & dropped on another place.
  * The order of the tasks is kept even though apps are started/terminated.
     * Newly opened apps are added to the very right of the task bar list.
* Multi-monitor support.
  * Have a separate task bar for each of the monitors.
  * The particular task bar shows only task from the particular monitor.