### PR TITLE
Keep stable order of tasks on the taskbar.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1554,7 +1554,7 @@ TaskBar.prototype =
         {
             this.countTasks = null;
             this.cleanTasksList();
-            windowsList.forEach(
+            windowsList.sort(this.sortWindowsCompareFunction).forEach(
                 function(window)
                 {
                     this.addTaskInList(window);
@@ -1572,6 +1572,11 @@ TaskBar.prototype =
             this.removeTaskInList(window);
             this.hidePreview();
         }
+    },
+
+    sortWindowsCompareFunction: function(windowA, windowB)
+    {
+        return windowA.get_stable_sequence() > windowB.get_stable_sequence();
     },
 
     //Active Tasks


### PR DESCRIPTION
The tasks are sorted in order of their start up time on the task bar even though new apps are started and other apps are terminated. This is a must for easy navigation and UI good practise – icons are not continuously moving without user's intention.

The order of the tasks is defined base on stable sequence IDs of their windows (see https://developer.gnome.org/meta/stable/MetaWindow.html#meta-window-get-stable-sequence).

-----

My wish list (but I do not know the GNOME extension development and API enough):

* User defined order of the tasks on the task bar (very needed function of good old GNOME 2).
  * Any app icon on the task bar can be dragged & dropped on another place.
  * The order of the tasks is kept even though apps are started/terminated.
     * Newly opened apps are added to the very right of the task bar list.
* Multi-monitor support.
  * Have a separate task bar for each of the monitors.
  * The particular task bar shows only task from the particular monitor.
