### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "3.12", 
     "3.14", 
     "3.16", 
-    "3.18"
+    "3.18",
+    "3.20"
   ], 
   "url": "https://github.com/zpydr/gnome-shell-extension-taskbar", 
   "uuid": "TaskBar@zpydr", 


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!